### PR TITLE
-Added Corsair (mirrors Bard logic)

### DIFF
--- a/behaviors/buffs.lua
+++ b/behaviors/buffs.lua
@@ -5,27 +5,38 @@ local packets = require('packets');
 
 local spells = packets.spells;
 local status = packets.status;
+
+-- What is level, and are we talking about your main job or sub job?  Takes into account level sync!
+-- @param true/false on checking for SUBJOB
+function JobLvlCheck (isSub)
+    local iparty = AshitaCore:GetDataManager():GetParty();
+    local lvl = AshitaCore:GetDataManager():GetParty():GetMemberMainJobLevel(0);
+    if (isSub) then
+      local maxlvlsub = AshitaCore:GetDataManager():GetPlayer():GetSubJobLevel();
+      lvl = math.min(math.modf(lvl/2),maxlvlsub);
+    end
+    return lvl
+end
+
 return {
 
   -- Can the player cast this spell?
   -- @param the spell id
   -- @param the spell level table
+  -- @param true/false on checking for SUBJOB
   CanCast = function(self, spell, levels, isSub)
-    local iparty = AshitaCore:GetDataManager():GetParty();
     local player = AshitaCore:GetDataManager():GetPlayer();
-    local lvl = iparty:GetMemberMainJobLevel(0);
-    if (isSub) then
-      lvl = ipary:GetMemberSubJobLevel(0);
-    end
+    local lvl = JobLvlCheck(isSub);
     return player:HasSpell(spell) and levels[spell] ~= nil and lvl >= levels[spell];
   end,
 
   -- Can the player use this ability?
   -- @param the ability id
   -- @param the ability level table
-  IsAble = function(self, ability, levels)
-    local player = AshitaCore:GetDataManager():GetPlayer();
-    local lvl = AshitaCore:GetDataManager():GetParty():GetMemberMainJobLevel(0);
+  -- @param true/false on checking for SUBJOB
+  IsAble = function(self, ability, levels, isSub)
+    local iparty = AshitaCore:GetDataManager():GetParty();
+    local lvl = JobLvlCheck(isSub);
     return levels[ability] ~= nil and lvl >= levels[ability];
   end,
 

--- a/combat.lua
+++ b/combat.lua
@@ -14,6 +14,7 @@ local jthf = require('jobs.thf');
 local jwar = require('jobs.war');
 local jwhm = require('jobs.whm');
 local jmnk = require('jobs.mnk');
+local jcor = require('jobs.cor');
 
 local map = {};
 map[Jobs.BlackMage] = jblm;
@@ -26,6 +27,7 @@ map[Jobs.Thief] = jthf;
 map[Jobs.Warrior] = jwar;
 map[Jobs.WhiteMage] = jwhm;
 map[Jobs.Monk] = jmnk;
+map[Jobs.Corsair] = jcor;
 
 local healing = false;
 

--- a/commands.lua
+++ b/commands.lua
@@ -4,6 +4,7 @@ local combat = require('combat');
 local config = require('config');
 local fov = require('fov');
 local jbrd = require('jobs.brd');
+local jcor = require('jobs.cor');
 
 local queue = {};
 local start = 0;
@@ -26,6 +27,7 @@ return {
     local chatType = struct.unpack('b', packet, 0x4 + 1);
     if (chatType ~= packets.CHAT_TYPE_LINKSHELL2) then return end
 
+    local player = AshitaCore:GetDataManager():GetPlayer();
     local actor = struct.unpack('s', packet, 0x8 + 1);
     local msg = struct.unpack('s', packet, 0x18 + 1);
     local args = msg:args();
@@ -80,8 +82,10 @@ return {
       actions:queue(actions:InteractNpc(args[2], args[3]));
     elseif (args[1] == 'setweaponskill') then
       self:SetWeaponSkill(args[2]);
-    elseif (args[1] == 'bard' and Jobs.Bard == AshitaCore:GetDataManager():GetPlayer():GetMainJob()) then
+    elseif (args[1] == 'bard' and (Jobs.Bard == player:GetMainJob() or Jobs.Bard == player:GetSubJob())) then
       jbrd:bard(unpack(args));
+    elseif (args[1] == 'corsair' and (Jobs.Corsair == player:GetMainJob() or Jobs.Corsair == player:GetSubJob())) then
+      jcor:corsair(unpack(args));
     end
   end,
 

--- a/config.lua
+++ b/config.lua
@@ -2,7 +2,8 @@ local config = nil;
 
 function load_settings(player)
   config = ashita.settings.load_merged(_addon.path .. '/settings/' .. player .. '/settings.json', {
-    bard = {}
+    bard = {},
+    corsair = {}
   });
   return config;
 end

--- a/jobs/brd.lua
+++ b/jobs/brd.lua
@@ -7,7 +7,7 @@ local healing = require('behaviors.healing');
 local jwhm = require('jobs.whm');
 
 local spells = packets.spells;
-local status = packets.status;
+local stoe = packets.stoe;
 
 local spell_levels = {};
 spell_levels[packets.spells.KNIGHTS_MINNE] = 1;
@@ -39,18 +39,9 @@ spell_levels[packets.spells.FOE_REQUIEM_IV] = 47;
 spell_levels[packets.spells.MAGES_BALLAD_II] = 55;
 spell_levels[packets.spells.CHOCOBO_MAZURKA] = 73;
 
--- spells to effect
-local stoe = {
-  MAGES_BALLAD = packets.status.EFFECT_BALLAD,
-  MAGES_BALLAD_II = packets.status.EFFECT_BALLAD,
-  ARMYS_PAEON = packets.status.EFFECT_PAEON,
-  ARMYS_PAEON_II = packets.status.EFFECT_PAEON,
-  ARMYS_PAEON_III = packets.status.EFFECT_PAEON,
-  ARMYS_PAEON_IV = packets.status.EFFECT_PAEON,
-  RAPTOR_MAZURKA = packets.status.EFFECT_MAZURKA,
-};
 
 return {
+  spell_levels = spell_levels,
 
   tick = function(self)
     if (actions.busy) then return end

--- a/jobs/cor.lua
+++ b/jobs/cor.lua
@@ -1,0 +1,169 @@
+local config = require('config');
+local party = require('party');
+local actions = require('actions');
+local packets = require('packets');
+local buffs = require('behaviors.buffs')
+local healing = require('behaviors.healing');
+local jdnc = require('jobs.dnc');
+local jbrd = require('jobs.brd');
+
+local spells = packets.spells;
+local stoe = packets.stoe;
+local abilities = packets.abilities;
+
+local ability_levels = {};
+ability_levels[abilities.CORSAIRS_ROLL] = 5;
+ability_levels[abilities.NINJA_ROLL] = 8;
+ability_levels[abilities.HUNTERS_ROLL] = 11;
+ability_levels[abilities.CHAOS_ROLL] = 14;
+ability_levels[abilities.MAGUSS_ROLL] = 17;
+ability_levels[abilities.HEALERS_ROLL] = 20;
+ability_levels[abilities.DRACHEN_ROLL] = 23;
+ability_levels[abilities.CHORAL_ROLL] = 26;
+ability_levels[abilities.MONKS_ROLL] = 31;
+ability_levels[abilities.BEAST_ROLL] = 34;
+ability_levels[abilities.SAMURAI_ROLL] = 37;
+ability_levels[abilities.EVOKERS_ROLL] = 40;
+ability_levels[abilities.ROGUES_ROLL] = 43;
+ability_levels[abilities.WARLOCKS_ROLL] = 46;
+ability_levels[abilities.FIGHTERS_ROLL] = 49;
+ability_levels[abilities.PUPPET_ROLL] = 52;
+ability_levels[abilities.GALLANTS_ROLL] = 55;
+ability_levels[abilities.WIZARDS_ROLL] = 58;
+ability_levels[abilities.DANCERS_ROLL] = 61;
+ability_levels[abilities.SCHOLARS_ROLL] = 64;
+
+return {
+  ability_levels = ability_levels,
+
+  tick = function(self)
+
+    if (actions.busy) then return end
+
+    local status = party:GetBuffs(0);
+    if (status[packets.status.EFFECT_INVISIBLE]) then return end
+
+    -- CORSAIR ROLLS - TO BE FIXED TO RE-ROLL FOR DOUBLE UPS --
+    local cnf = config:get();
+    if (cnf.corsair.rollvar1 and not(status[stoe[cnf.corsair.rollvar1]])) then
+      if (buffs:IsAble(abilities[cnf.corsair.rollvar1], ability_levels)) then
+        actions.busy = true;
+        actions:queue(actions:new()
+          :next(partial(ability, '"' .. cnf.corsair.roll1 .. '"', '<me>'))
+          :next(partial(wait, 7))
+          :next(function(self) actions.busy = false; end));
+        return;
+      end
+    end
+    if (cnf.corsair.rollvar2 and not(status[stoe[cnf.corsair.rollvar2]])) then
+      if (buffs:IsAble(abilities[cnf.corsair.rollvar2], ability_levels)) then
+        actions.busy = true;
+        actions:queue(actions:new()
+          :next(partial(ability, '"' .. cnf.corsair.roll2 .. '"', '<me>'))
+          :next(partial(wait, 7))
+          :next(function(self) actions.busy = false; end));
+        return;
+      end
+    end
+
+    -- ATTACKING AND WEAPONSKILLING
+    local tp = AshitaCore:GetDataManager():GetParty():GetMemberCurrentTP(0);
+    local tid = AshitaCore:GetDataManager():GetTarget():GetTargetServerId();
+    if (cnf.ATTACK_TID and tid ~= cnf.ATTACK_TID) then
+      cnf.ATTACK_TID = nil;
+      AshitaCore:GetChatManager():QueueCommand("/follow " .. cnf.leader, 1);
+    elseif (cnf.ATTACK_TID and tid == cnf.ATTACK_TID and tp >= 1000) then
+      if (cnf.WeaponSkillID ~= nil ) then
+        if AshitaCore:GetDataManager():GetPlayer():HasWeaponSkill(tonumber(cnf.WeaponSkillID)) then
+          for k, v in pairs(packets.weaponskills) do
+            if (tonumber(cnf.WeaponSkillID) == tonumber(v)) then
+              AshitaCore:GetChatManager():QueueCommand('/ws "' .. string.gsub(k,"_"," ") .. '" <t>', 1);
+            end
+          end
+        end
+      end
+    elseif (cnf.ATTACK_TID) then
+      AshitaCore:GetChatManager():QueueCommand("/ra <t>", 1);
+    end
+
+    -- SUBJOBS
+    local sub = AshitaCore:GetDataManager():GetPlayer():GetSubJob();
+    -- IF SUBJOB IS DANCER, DO DANCER THINGS
+    if (sub == Jobs.Dancer and cnf.ATTACK_TID ~= nil) then
+      local status = party:GetBuffs(0);
+      if (tp >= 150 and buffs:IsAble(abilities.DRAIN_SAMBA, jdnc.ability_levels) and status[stoe.DRAIN_SAMBA] ~= true) then
+        actions.busy = true;
+        actions:queue(actions:new()
+          :next(partial(ability, '"Drain Samba"', '<me>'))
+          :next(partial(wait, 8))
+          :next(function(self) actions.busy = false; end));
+        return;
+      end
+    -- IF SUBJOB IS BARD, DO BARD THINGS
+    elseif (sub == Jobs.Bard and (cnf.bard.songvar1 and not(status[stoe[cnf.bard.songvar1]]))) then
+      if (buffs:CanCast(spells[cnf.bard.songvar1], jbrd.spell_levels, true)) then
+        actions.busy = true;
+        actions:queue(actions:new()
+          :next(partial(magic, '"' .. cnf.bard.song1 .. '"', '<me>'))
+          :next(partial(wait, 7))
+          :next(function(self) actions.busy = false; end));
+        return;
+      end
+    end
+  end,
+
+  attack = function(self, tid)
+    actions:queue(actions:new()
+      :next(function(self)
+        AshitaCore:GetChatManager():QueueCommand('/attack ' .. tid, 0);
+      end)
+      :next(function(self)
+        config:get().ATTACK_TID = tid;
+        AshitaCore:GetChatManager():QueueCommand('/follow ' .. tid, 0);
+      end)
+      );
+  end,
+
+  corsair = function(self, corsair, command, roll)
+    local cnf = config:get();
+    local cor = cnf['corsair'];
+    local onoff = cor['roll'] and 'on' or 'off';
+    local roll1 = cor['roll1'] or 'none';
+    local roll2 = cor['roll2'] or 'none';
+
+    local rollvar;
+    if(roll ~= nil) then
+      rollvar = roll:upper():gsub("'", ""):gsub(" ", "_");
+    end
+
+    if (command ~= nil) then
+      if (command == 'on' or command == 'true') then
+        cor['roll'] = true;
+        onoff = 'on';
+      elseif (command == 'off' or command == 'false') then
+        cor['roll'] = false;
+        onoff = 'off';
+      elseif (command == '1' and roll and abilities[rollvar]) then
+        cor['roll1'] = roll;
+        cor['rollvar1'] = rollvar;
+        roll1 = roll;
+      elseif (command == '2' and roll and abilities[rollvar]) then
+        cor['roll2'] = roll;
+        cor['rollvar2'] = rollvar;
+        roll2 = roll;
+      elseif (command =='1' and roll == 'none') then
+        cor['roll1'] = nil;
+        cor['rollvar1'] = nil;
+        roll1 = 'none';
+      elseif (command =='2' and roll == 'none') then
+        cor['roll2'] = nil;
+        cor['rollvar2'] = nil;
+        roll2 = 'none';
+      end
+      config:save();
+    end
+
+    AshitaCore:GetChatManager():QueueCommand('/l2 I\'m a Corsair!\nrolling: ' .. onoff .. '\n1: ' .. roll1 .. '\n2: ' .. roll2, 1);
+  end
+
+};

--- a/jobs/dnc.lua
+++ b/jobs/dnc.lua
@@ -6,11 +6,11 @@ local buffs = require('behaviors.buffs')
 local healing = require('behaviors.healing');
 
 local spells = packets.spells;
-local status = packets.status;
+local stoe = packets.stoe;
 local abilities = packets.abilities;
 
 local ability_levels = {};
-ability_levels[packets.abilities.DRAIN_SAMBA] = 5;
+ability_levels[abilities.DRAIN_SAMBA] = 5;
 
 return {
   ability_levels = ability_levels,
@@ -28,7 +28,7 @@ return {
     if (cnf.ATTACK_TID ~= nil) then
       local status = party:GetBuffs(0);
       local tp = AshitaCore:GetDataManager():GetParty():GetMemberCurrentTP(0);
-      if (tp >= 150 and buffs:IsAble(abilities.DRAIN_SAMBA, ability_levels) and status[packets.status.EFFECT_DRAIN_SAMBA] ~= true) then
+      if (tp >= 150 and buffs:IsAble(abilities.DRAIN_SAMBA, ability_levels) and status[stoe.DRAIN_SAMBA] ~= true) then
         actions.busy = true;
         actions:queue(actions:new()
           :next(partial(ability, '"Drain Samba"', '<me>'))

--- a/packets.lua
+++ b/packets.lua
@@ -95,11 +95,52 @@ local packets = {
     EFFECT_MINUET                   = 198,
     EFFECT_MAZURKA                  = 219,
     EFFECT_FOOD                     = 251,
+    EFFECT_FIGHTERS_ROLL            = 310,
+    EFFECT_MONKS_ROLL               = 311,
+    EFFECT_HEALERS_ROLL             = 312,
+    EFFECT_WIZARDS_ROLL             = 313,
+    EFFECT_WARLOCKS_ROLL            = 314,
+    EFFECT_ROGUES_ROLL              = 315,
+    EFFECT_GALLANTS_ROLL            = 316,
+    EFFECT_CHAOS_ROLL               = 317,
+    EFFECT_BEAST_ROLL               = 318,
+    EFFECT_CHORAL_ROLL              = 319,
+    EFFECT_HUNTERS_ROLL             = 320,
+    EFFECT_SAMURAI_ROLL             = 321,
+    EFFECT_NINJA_ROLL               = 322,
+    EFFECT_DRACHEN_ROLL             = 323,
+    EFFECT_EVOKERS_ROLL             = 324,
+    EFFECT_MAGUSS_ROLL              = 325,
+    EFFECT_CORSAIRS_ROLL            = 326,
+    EFFECT_PUPPET_ROLL              = 327,
+    EFFECT_DANCERS_ROLL             = 328,
+    EFFECT_SCHOLARS_ROLL            = 329,
     EFFECT_DRAIN_SAMBA              = 368,
     EFFECT_POISON_II                = 540,
   },
 
   abilities = {
+    PHANTOM_ROLL = 81,
+    FIGHTERS_ROLL = 82,
+    MONKS_ROLL = 83,
+    HEALERS_ROLL = 84,
+    WIZARDS_ROLL = 85,
+    WARLOCKS_ROLL = 86,
+    ROGUES_ROLL = 87,
+    GALLANTS_ROLL = 88,
+    CHAOS_ROLL = 89,
+    BEAST_ROLL = 90,
+    CHORAL_ROLL = 91,
+    HUNTERS_ROLL = 92,
+    SAMURAI_ROLL = 93,
+    NINJA_ROLL = 94,
+    DRACHEN_ROLL = 95,
+    EVOKERS_ROLL = 96,
+    MAGUSS_ROLL = 97,
+    CORSAIRS_ROLL = 98,
+    PUPPET_ROLL = 99,
+    DANCERS_ROLL = 100,
+    SCHOLARS_ROLL = 101,
     DRAIN_SAMBA = 168,
   },
 
@@ -193,8 +234,40 @@ local packets = {
   weaponskills = {
     COMBO = 1,
     SHOULDER_TACKLE = 2,
-    CYCLONE = 20
-  }
+    CYCLONE = 20,
+  },
 
+  stoe = {}
 };
+
+packets.stoe.MAGES_BALLAD = packets.status.EFFECT_BALLAD;
+packets.stoe.MAGES_BALLAD_II = packets.status.EFFECT_BALLAD;
+packets.stoe.ARMYS_PAEON = packets.status.EFFECT_PAEON;
+packets.stoe.ARMYS_PAEON_II = packets.status.EFFECT_PAEON;
+packets.stoe.ARMYS_PAEON_III = packets.status.EFFECT_PAEON;
+packets.stoe.ARMYS_PAEON_IV = packets.status.EFFECT_PAEON;
+packets.stoe.RAPTOR_MAZURKA = packets.status.EFFECT_MAZURKA;
+packets.stoe.DRAIN_SAMBA = packets.status.EFFECT_DRAIN_SAMBA;
+packets.stoe.PHANTOM_ROLL = packets.status.EFFECT_PHANTOM_ROLL;
+packets.stoe.FIGHTERS_ROLL = packets.status.EFFECT_FIGHTERS_ROLL;
+packets.stoe.MONKS_ROLL = packets.status.EFFECT_MONKS_ROLL;
+packets.stoe.HEALERS_ROLL = packets.status.EFFECT_HEALERS_ROLL;
+packets.stoe.WIZARDS_ROLL = packets.status.EFFECT_WIZARDS_ROLL;
+packets.stoe.WARLOCKS_ROLL = packets.status.EFFECT_WARLOCKS_ROLL;
+packets.stoe.ROGUES_ROLL = packets.status.EFFECT_ROGUES_ROLL;
+packets.stoe.GALLANTS_ROLL = packets.status.EFFECT_GALLANTS_ROLL;
+packets.stoe.CHAOS_ROLL = packets.status.EFFECT_CHAOS_ROLL;
+packets.stoe.BEAST_ROLL = packets.status.EFFECT_BEAST_ROLL;
+packets.stoe.CHORAL_ROLL = packets.status.EFFECT_CHORAL_ROLL;
+packets.stoe.HUNTERS_ROLL = packets.status.EFFECT_HUNTERS_ROLL;
+packets.stoe.SAMURAI_ROLL = packets.status.EFFECT_SAMURAI_ROLL;
+packets.stoe.NINJA_ROLL = packets.status.EFFECT_NINJA_ROLL;
+packets.stoe.DRACHEN_ROLL = packets.status.EFFECT_DRACHEN_ROLL;
+packets.stoe.EVOKERS_ROLL = packets.status.EFFECT_EVOKERS_ROLL;
+packets.stoe.MAGUSS_ROLL = packets.status.EFFECT_MAGUSS_ROLL;
+packets.stoe.CORSAIRS_ROLL = packets.status.EFFECT_CORSAIRS_ROLL;
+packets.stoe.PUPPET_ROLL = packets.status.EFFECT_PUPPET_ROLL;
+packets.stoe.DANCERS_ROLL = packets.status.EFFECT_DANCERS_ROLL;
+packets.stoe.SCHOLARS_ROLL = packets.status.EFFECT_SCHOLARS_ROLL;
+
 return packets;

--- a/seven.lua
+++ b/seven.lua
@@ -185,6 +185,11 @@ ashita.register_event('command', function(cmd, nType)
       args[4] = '"'..args[4]..'"';
     end
     AshitaCore:GetChatManager():QueueCommand('/l2 bard ' .. (args[3] or '') .. ' ' .. (args[4] or ''), 1);
+  elseif (args[2] == 'corsair') then
+    if (args[4]) then
+      args[4] = '"'..args[4]..'"';
+    end
+    AshitaCore:GetChatManager():QueueCommand('/l2 corsair ' .. (args[3] or '') .. ' ' .. (args[4] or ''), 1);
   elseif (args[2] == 'yaw') then
     local ientity = AshitaCore:GetDataManager():GetEntity();
     local rot = ientity:GetLocalYaw(GetPlayerEntity().TargetIndex);


### PR DESCRIPTION
-Added all Corsair rolls to packets, both Spell IDs and Effect IDs
-Moved existing "stoe" checks and tables to be global as part of packets.lua
     -Included DNC for future expansion to cast different levels of drain samba automatically...
-Modified Bard to be used for subjob checks
-Modified Buffs.lua coding on main job / subjob lvl checks to account for error in Ashita iParty subjob error